### PR TITLE
Delete Codecov support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,14 +4,12 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@main
-    - name: Build and test
-      run: xcodebuild test -scheme TreePicker -destination "platform=iOS Simulator,name=iPhone 15" -destination "platform=macOS,arch=arm64"
-  run:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@main
-    - name: Upload coverage reports to Codecov
+    - uses: actions/checkout@codecov-reports
+    - name: Build
+      run: swift build
+    - name: Test
+      run: swift test --enable-code-coverage
+    - name: Prepare test coverage
       uses: codecov/codecov-action@v4.3.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,9 @@ jobs:
       run: swift build
     - name: Test
       run: swift test --enable-code-coverage
-    - name: Prepare test coverage
+    - name: Test coverage
+      uses: maxep/spm-lcov-action@0.3.0
+    - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4.3.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,9 +9,3 @@ jobs:
       run: swift build
     - name: Test
       run: swift test --enable-code-coverage
-    #- name: Prepare test coverage
-    #  run: ???
-    - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v4.3.1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Test
       run: swift test --enable-code-coverage
     - name: Test coverage
-      uses: maxep/spm-lcov-action@0.3.0
+      uses: mattpolzin/swift-codecov-action@0.7.5
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4.3.1
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,8 +9,8 @@ jobs:
       run: swift build
     - name: Test
       run: swift test --enable-code-coverage
-    - name: Prepare test coverage
-      uses: maxep/spm-lcov-action@0.3.1
+    #- name: Prepare test coverage
+    #  run: ???
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4.3.1
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,15 +2,15 @@ name: build and test
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@main
     - name: Build
       run: swift build
     - name: Test
       run: swift test --enable-code-coverage
-    - name: Test coverage
-      uses: mattpolzin/swift-codecov-action@0.7.5
+    - name: Prepare test coverage
+      uses: maxep/spm-lcov-action@0.3.1
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4.3.1
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: build and test
 on: [push]
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
     - name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@codecov-reports
+    - uses: actions/checkout@main
     - name: Build
       run: swift build
     - name: Test

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,9 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "TreePicker"),
+            name: "TreePicker",
+            resources: [.process("Resources")]
+        ),
         .testTarget(
             name: "TreePickerTests",
             dependencies: ["TreePicker"]),

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A pack of SwiftUI tree pickers that provide selecting options from hierarchical 
 
 [![Latest release](https://img.shields.io/github/v/release/borisovodov/TreePicker)](https://github.com/borisovodov/TreePicker/releases)
 [![Build and test status](https://github.com/borisovodov/TreePicker/actions/workflows/workflow.yml/badge.svg)](https://github.com/borisovodov/TreePicker/actions/workflows/workflow.yml)
-[![Code coverage status](https://img.shields.io/codecov/c/github/borisovodov/TreePicker)](https://codecov.io/gh/borisovodov/TreePicker)
 [![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fborisovodov%2FTreePicker%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/borisovodov/TreePicker)
 [![Available platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fborisovodov%2FTreePicker%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/borisovodov/TreePicker)
 


### PR DESCRIPTION
I didn't understand how to use `llvm-cov` command inside Github actions environment in macOS. Linux hasn't `SwiftUI` module, macOS environment hasn't `llvm-cov`. Without this command I can't recreate coverage report to codecov format: https://community.codecov.com/t/swift-package-support/675/4. So I gave up and delete all  codecov artefacts from source code.